### PR TITLE
Fixed Makefile.config to set Pinplay as default

### DIFF
--- a/Makefile.config
+++ b/Makefile.config
@@ -13,16 +13,13 @@ endif
 export SIM_ROOT
 PIN_HOME ?= $(SIM_ROOT)/pin_kit
 SDE_HOME ?= $(SIM_ROOT)/sde_kit
-ifneq (,$(USE_PIN))
-undefine SDE_HOME
-undefine SDE_BUILD_KIT
-else ifneq (,$(USE_PINPLAY))
-undefine SDE_HOME
-undefine SDE_BUILD_KIT
-else
+ifneq (,$(USE_SDE))
 PIN_HOME := $(SIM_ROOT)/sde_kit/pinkit
 SDE_BUILD_KIT := $(SDE_HOME)
 export SDE_BUILD_KIT
+else
+undefine SDE_HOME
+undefine SDE_BUILD_KIT
 endif
 PIN_ROOT := $(PIN_HOME)
 export PIN_ROOT


### PR DESCRIPTION
Hello, to compile correctly using Pinplay as the default it was still necessary to use make USE_PINPLAY=1 -j. I fixed the Makefile.config also to set Pinplay as default.

As you asked me, in this update, I combined the patches to fix the Makefile.config and removed the xed link.
Thank you!