### PR TITLE
[sift_recorder] Inaccurate 'tidptr' mapping during clone in a multi-threaded workload.

### DIFF
--- a/sift/recorder/globals.cc
+++ b/sift/recorder/globals.cc
@@ -45,7 +45,7 @@ UINT64 fast_forward_target = 0;
 UINT64 detailed_target = 0;
 PIN_LOCK access_memory_lock;
 PIN_LOCK new_threadid_lock;
-std::deque<ADDRINT> tidptrs;
+std::unordered_map<int, std::deque<ADDRINT>> tidptrs;
 PIN_LOCK output_lock;
 INT32 child_app_id = -1;
 BOOL in_roi = false;

--- a/sift/recorder/globals.h
+++ b/sift/recorder/globals.h
@@ -58,7 +58,7 @@ extern UINT64 detailed_target;
 extern PIN_LOCK access_memory_lock;
 extern PIN_LOCK new_threadid_lock;
 extern PIN_LOCK output_lock;
-extern std::deque<ADDRINT> tidptrs;
+extern std::unordered_map<int, std::deque<ADDRINT>> tidptrs;
 extern INT32 child_app_id;
 extern BOOL in_roi;
 extern BOOL any_thread_in_detail;

--- a/sift/recorder/syscall_modeling.cc
+++ b/sift/recorder/syscall_modeling.cc
@@ -110,7 +110,7 @@ VOID emulateSyscallFunc(THREADID threadid, CONTEXT *ctxt)
                struct clone_args_sniper* clone3_args = (struct clone_args_sniper*)args[0];
                ADDRINT tidptr = clone3_args->parent_tid;
                PIN_GetLock(&new_threadid_lock, threadid);
-               tidptrs.push_back(tidptr);
+               tidptrs[PIN_GetTid()].push_back(tidptr);
                PIN_ReleaseLock(&new_threadid_lock);
                /* New thread */
                thread_data[threadid].output->NewThread();
@@ -137,7 +137,7 @@ VOID emulateSyscallFunc(THREADID threadid, CONTEXT *ctxt)
                #endif
 
                PIN_GetLock(&new_threadid_lock, threadid);
-               tidptrs.push_back(tidptr);
+               tidptrs[PIN_GetTid()].push_back(tidptr);
                PIN_ReleaseLock(&new_threadid_lock);
                /* New thread */
                thread_data[threadid].output->NewThread();

--- a/sift/recorder/threads.cc
+++ b/sift/recorder/threads.cc
@@ -27,10 +27,10 @@ static VOID threadStart(THREADID threadid, CONTEXT *ctxt, INT32 flags, VOID *v)
 
    // The first thread (master) doesn't need to join with anyone else
    PIN_GetLock(&new_threadid_lock, threadid);
-   if (tidptrs.size() > 0)
+   if (tidptrs[PIN_GetParentTid()].size() > 0)
    {
-      thread_data[threadid].tid_ptr = tidptrs.front();
-      tidptrs.pop_front();
+      thread_data[threadid].tid_ptr = tidptrs[PIN_GetParentTid()].front();
+      tidptrs[PIN_GetParentTid()].pop_front();
    }
    PIN_ReleaseLock(&new_threadid_lock);
 

--- a/test/thread-in-thread/Makefile
+++ b/test/thread-in-thread/Makefile
@@ -1,0 +1,8 @@
+TARGET=thread-in-thread
+include ../shared/Makefile.shared
+
+$(TARGET): $(TARGET).o
+	$(CC) $(TARGET).o -lm $(SNIPER_LDFLAGS) -o $(TARGET)
+
+run_$(TARGET):
+	../../run-sniper -n 4 -- ./thread-in-thread

--- a/test/thread-in-thread/thread-in-thread.cc
+++ b/test/thread-in-thread/thread-in-thread.cc
@@ -1,0 +1,33 @@
+#include <pthread.h>
+
+#define THREAD_NUM 5
+
+void *spin(void* ptr)
+{
+    for (int i = 0; i < 100; i++)
+        ;
+}
+
+void *thread_in_thread(void *ptr)
+{
+    pthread_t threads[THREAD_NUM];
+
+    for (int i = 0; i < THREAD_NUM; i++)
+        pthread_create(&threads[i], NULL, *spin, NULL);
+
+    for (int i = 0; i < THREAD_NUM; i++)
+        pthread_join(threads[i], NULL);
+}
+
+int main()
+{
+    pthread_t threads[THREAD_NUM];
+    
+    for (int i = 0; i < THREAD_NUM; i++)
+        pthread_create(&threads[i], NULL, *thread_in_thread, NULL);
+
+    for (int i = 0; i < THREAD_NUM; i++)
+        pthread_join(threads[i], NULL);
+
+    return 0;
+}


### PR DESCRIPTION
Hi,

I fixed the issue where `tidptr` was inaccurately mapped to the child thread.
This issue occurs when executing clone syscall simultaneously within multiple threads.

The sift_recorder calls `emulateSyscallFunc()` before the `clone` syscall and pushes `tidptr` into the global variable `tidptrs`. When the child thread is created, and the `threadStart()` function is called, it pops `tidptr` from the front of `tidptrs` and stores it in `thread_data`.

The problem is the order in which `tidptr` is pushed and the order in which it is popped in the child thread does not match when multiple threads clone simultaneously.

To resolve this issue, I have modified `tidptrs` to `std::unordered_map<int, std::deque<ADDRINT>>` in order to separate `tidptr` for each thread. By using the parent tid for pushing, child threads can accurately find `tidptr` using `PIN_GetParentTid()`.