### PR TITLE
Update SDE to 9.38, PIN to 3.31

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -20,29 +20,6 @@ PYTHON2=python2
 
 all: message dependencies $(SIM_TARGETS) configscripts
 
-include common/Makefile.common
-
-dependencies: package_deps sde_kit $(PIN_ROOT) pin xed python mcpat linux builddir showdebugstatus
-
-BUILD_CAPSTONE ?=
-ifeq ($(BUILD_ARM),1)
-BUILD_CAPSTONE=1
-else ifeq ($(BUILD_DYNAMORIO),1)
-BUILD_CAPSTONE=1
-endif
-
-ifeq ($(BUILD_CAPSTONE),1)
-dependencies: capstone
-.PHONY: capstone
-endif
-
-ifeq ($(BUILD_DYNAMORIO),1)
-dependencies: dynamorio
-.PHONY: dynamorio
-endif
-
-$(SIM_TARGETS): dependencies
-
 # Check for errors. Only one value should be set
 TARGET_COUNT:=0
 # For Pin
@@ -71,13 +48,38 @@ $(error If using, set USE_SDE to "1", not "$(USE_SDE)")
 endif
 # Set the default if no values are set
 ifeq ($(TARGET_COUNT),0)
-USE_PINPLAY=1
+# USE_PINPLAY=1
+USE_SDE=1
+export USE_SDE #Makefile.config needs that variable
 else ifeq ($(TARGET_COUNT),1)
 # Input is valid. Use user-supplied default
 else
 # Error, cannot be >= 2
 $(error One or more tools requested for build. Only one supported USE_PIN=$(USE_PIN) USE_PINPLAY=$(USE_PINPLAY) USE_SDE=$(USE_SDE))
 endif
+
+include common/Makefile.common
+
+dependencies: package_deps sde_kit $(PIN_ROOT) pin xed python mcpat linux builddir showdebugstatus
+
+BUILD_CAPSTONE ?=
+ifeq ($(BUILD_ARM),1)
+BUILD_CAPSTONE=1
+else ifeq ($(BUILD_DYNAMORIO),1)
+BUILD_CAPSTONE=1
+endif
+
+ifeq ($(BUILD_CAPSTONE),1)
+dependencies: capstone
+.PHONY: capstone
+endif
+
+ifeq ($(BUILD_DYNAMORIO),1)
+dependencies: dynamorio
+.PHONY: dynamorio
+endif
+
+$(SIM_TARGETS): dependencies
 
 message:
 	@echo -n Building for x86 \($(SNIPER_TARGET_ARCH)\)
@@ -211,8 +213,9 @@ $(PIN_DEP):
 	$(_CMD) touch $(PIN_HOME)/.autodownloaded
 sde_kit: $(PIN_ROOT)
 else
-SDE_DOWNLOAD=https://snipersim.org/packages/sde-external-9.7.0-2022-05-09-lin.tar.xz
-PIN_DEP=$(SDE_HOME)/intel64/pin_lib/libpin3dwarf.so
+# SDE_DOWNLOAD=https://snipersim.org/packages/sde-external-9.7.0-2022-05-09-lin.tar.xz
+SDE_DOWNLOAD=https://downloadmirror.intel.com/823664/sde-external-9.38.0-2024-04-18-lin.tar.xz
+PIN_DEP=$(SDE_HOME)/intel64/pin_lib/libpindwarf.so
 sde_kit: $(PIN_DEP)
 $(PIN_DEP):
 	$(_MSG) '[DOWNLO] SDE 9.7.0-2022-05-09'
@@ -220,6 +223,7 @@ $(PIN_DEP):
 	$(_CMD) wget -O $(shell basename $(SDE_DOWNLOAD)) $(WGET_OPTIONS) --no-verbose --quiet $(SDE_DOWNLOAD)
 	$(_CMD) tar -x -f $(shell basename $(SDE_DOWNLOAD)) --auto-compress --strip-components 1 -C $(SDE_HOME)
 	$(_CMD) rm $(shell basename $(SDE_DOWNLOAD))
+	$(_CMD) rm -r $(SDE_HOME)/pinkit/source/tools/InstLib #It looks like it is missing source files, so it fails to compile but not necessary for sniper
 	$(_CMD) touch $(SDE_HOME)/.autodownloaded
 	$(_MSG) '[DOWNLO] pinplay-tools'
 	$(_CMD) git clone --quiet https://github.com/intel/pinplay-tools $(SDE_HOME)/pinplay-tools

--- a/Makefile
+++ b/Makefile
@@ -20,6 +20,9 @@ PYTHON2=python2
 
 all: message dependencies $(SIM_TARGETS) configscripts
 
+#NOTE PINPLAY: This is not updated to the latest version: 1) SDE already contains pinplay, 2) the pinplay-driver (inside the pinplay_toolkit github) cannot easily be build for PIN. 3) The latest pinplay version has a bug preventing to read pinballs.
+#KNOWN ISSUE WITH SDE: It cannot run properly inside virtualbox
+
 # Check for errors. Only one value should be set
 TARGET_COUNT:=0
 # For Pin
@@ -48,7 +51,7 @@ $(error If using, set USE_SDE to "1", not "$(USE_SDE)")
 endif
 # Set the default if no values are set
 ifeq ($(TARGET_COUNT),0)
-# USE_PINPLAY=1
+# USE_PIN=1
 USE_SDE=1
 export USE_SDE #Makefile.config needs that variable
 else ifeq ($(TARGET_COUNT),1)
@@ -165,35 +168,31 @@ $(CAPSTONE_BUILD_DEP): $(CAPSTONE_INSTALL_DEP)
 	$(_CMD) cd $(CAPSTONE_INSTALL) ; ./make.sh
 
 
-MBUILD_GITID=1651029643b2adf139a8d283db51b42c3c884513
 MBUILD_INSTALL=$(SIM_ROOT)/mbuild
 MBUILD_INSTALL_DEP=$(MBUILD_INSTALL)/mbuild/arar.py
 mbuild: $(MBUILD_INSTALL_DEP)
 $(MBUILD_INSTALL_DEP):
 	$(_MSG) '[DOWNLO] mbuild'
 	$(_CMD) git clone --quiet https://github.com/intelxed/mbuild.git $(MBUILD_INSTALL)
-	$(_CMD) git -C $(MBUILD_INSTALL) reset --quiet --hard $(MBUILD_GITID)
 
-XED_GITID=2be2d282939f6eb84e03e1fed9ba82f32c8bac2d
 XED_INSTALL_DEP=$(XED_INSTALL)/src/common/xed-init.c
 xed_install: $(XED_INSTALL_DEP)
 $(XED_INSTALL_DEP):
 	$(_MSG) '[DOWNLO] xed'
 	$(_CMD) git clone --quiet https://github.com/intelxed/xed.git $(XED_INSTALL)
-	$(_CMD) git -C $(XED_INSTALL) reset --quiet --hard $(XED_GITID)
 
 XED_DEP=$(XED_HOME)/include/xed/xed-iclass-enum.h
 xed: mbuild xed_install $(XED_DEP)
 $(XED_DEP): $(XED_INSTALL_DEP)
 	$(_MSG) '[INSTAL] xed'
-	$(_CMD) cd $(XED_INSTALL) ; $(PYTHON2) ./mfile.py --silent --extra-flags=-fPIC --shared --install-dir $(XED_HOME) install
+	$(_CMD) cd $(XED_INSTALL) ; ./mfile.py --silent --extra-flags=-fPIC --shared --install-dir $(XED_HOME) install
 
 ifneq (,$(USE_PIN))
-PIN_DOWNLOAD=https://snipersim.org/packages/pin-3.22-98547-g7a303a835-gcc-linux.tar.gz
-PIN_DEP=$(PIN_HOME)/intel64/lib-ext/libpin3dwarf.so
+PIN_DOWNLOAD=https://software.intel.com/sites/landingpage/pintool/downloads/pin-external-3.31-98861-g71afcc22f-gcc-linux.tar.gz
+PIN_DEP=$(PIN_HOME)/intel64/lib/libpindwarf.so
 $(PIN_ROOT): $(PIN_DEP)
 $(PIN_DEP):
-	$(_MSG) '[DOWNLO] Pin 3.22-98547'
+	$(_MSG) '[DOWNLO] Pin'
 	$(_CMD) mkdir -p $(PIN_HOME)
 	$(_CMD) wget -O $(shell basename $(PIN_DOWNLOAD)) $(WGET_OPTIONS) --no-verbose --quiet $(PIN_DOWNLOAD)
 	$(_CMD) tar -x -f $(shell basename $(PIN_DOWNLOAD)) --auto-compress --strip-components 1 -C $(PIN_HOME)

--- a/common/Makefile.common
+++ b/common/Makefile.common
@@ -61,7 +61,7 @@ CPPFLAGS+=$(foreach dir,$(INCLUDE_DIRECTORIES),-I$(dir)) \
           -I$(SIM_ROOT)/capstone/include -I$(SIM_ROOT)/capstone/include/capstone 
 
 CXXFLAGS+=-c \
-          -Wall -Wextra -Wcast-align -Wno-unused-parameter -Wno-unknown-pragmas -std=c++11 -fno-strict-aliasing $(OPT_CFLAGS) #-Werror	  
+          -Wall -Wextra -Wcast-align -Wno-unused-parameter -Wno-unknown-pragmas -std=c++20 -fno-strict-aliasing $(OPT_CFLAGS) #-Werror
 #CXXFLAGS+=-I$(SIM_ROOT)/rv8/src
 #CXXFLAGS+=-I$(SIM_ROOT)/rv8
 

--- a/common/core/memory_subsystem/cheetah/util.cc
+++ b/common/core/memory_subsystem/cheetah/util.cc
@@ -62,7 +62,7 @@ uint64_t **
 idim2(int row, int col)
 {
   int i;
-  register uint64_t **prow, *pdata;
+  uint64_t **prow, *pdata;
 
   pdata = (uint64_t *)calloc(row*col, sizeof (uint64_t));
   if (!pdata)
@@ -154,7 +154,7 @@ void
 rotate_right(int y, struct tree_node **p_stack)
 {
   int x,z;
-  register struct tree_node *t1, *t2, *t3;
+  struct tree_node *t1, *t2, *t3;
 
   z = y-1;
   x = y+1;

--- a/common/core/memory_subsystem/pr_l1_pr_l2_dram_directory_msi/dram_directory_cache.cc
+++ b/common/core/memory_subsystem/pr_l1_pr_l2_dram_directory_msi/dram_directory_cache.cc
@@ -34,7 +34,7 @@ DramDirectoryCache::DramDirectoryCache(
 
 DramDirectoryCache::~DramDirectoryCache()
 {
-   delete m_replacement_ptrs;
+   delete[] m_replacement_ptrs;
    delete m_directory;
 }
 

--- a/common/misc/circular_queue.h
+++ b/common/misc/circular_queue.h
@@ -2,6 +2,7 @@
 #define CIRCULAR_QUEUE_H
 
 #include <assert.h>
+#include <iterator>
 #include <string.h>
 
 template <class T> class CircularQueue
@@ -16,12 +17,18 @@ template <class T> class CircularQueue
 
    public:
       typedef T value_type;
-      class iterator : public std::iterator<std::forward_iterator_tag, T, std::ptrdiff_t, const T*, const T&>
+      class iterator
       {
          private:
             CircularQueue &_queue;
             UInt32 _idx;
          public:
+	    using iterator_category = std::forward_iterator_tag;
+	    using difference_type = std::ptrdiff_t;
+	    using value_type = T;
+	    using pointer = const T*;
+	    using reference = const T&;
+
             iterator(CircularQueue &queue, UInt32 idx) : _queue(queue), _idx(idx) {}
             T& operator*() const { return _queue.at(_idx); }
             T* operator->() const { return &_queue.at(_idx); }

--- a/common/performance_model/performance_models/micro_op/register_dependencies.cc
+++ b/common/performance_model/performance_models/micro_op/register_dependencies.cc
@@ -1,7 +1,8 @@
 #include "register_dependencies.h"
 #include "dynamic_micro_op.h"
 
-RegisterDependencies::RegisterDependencies()
+RegisterDependencies::RegisterDependencies():
+	producers(Sim()->getDecoder()->last_reg())
 {
    clear();
 }
@@ -53,8 +54,5 @@ uint64_t RegisterDependencies::peekProducer(dl::Decoder::decoder_reg reg, uint64
 
 void RegisterDependencies::clear()
 {
-   for(uint32_t i = 0; i < Sim()->getDecoder()->last_reg(); i++)
-   {
-      producers[i] = INVALID_SEQNR;
-   }
+   std::fill(producers.begin(), producers.end(), INVALID_SEQNR);
 }

--- a/common/performance_model/performance_models/micro_op/register_dependencies.h
+++ b/common/performance_model/performance_models/micro_op/register_dependencies.h
@@ -3,6 +3,7 @@
 
 #include <decoder.h>
 #include <vector>
+#include <cstdint>
 
 //extern "C" {
 //#include <xed-reg-enum.h>

--- a/common/performance_model/performance_models/micro_op/register_dependencies.h
+++ b/common/performance_model/performance_models/micro_op/register_dependencies.h
@@ -1,8 +1,8 @@
 #ifndef __REGISTER_DEPENDENCIES_H
 #define __REGISTER_DEPENDENCIES_H
 
-#include "fixed_types.h"
 #include <decoder.h>
+#include <vector>
 
 //extern "C" {
 //#include <xed-reg-enum.h>
@@ -12,10 +12,8 @@ class DynamicMicroOp;
 
 class RegisterDependencies {
 private:
-    // Array containing the sequence number of the producers for each of the registers.
-    // FIXME Depending on the architecture we may have too many elements
-    // Not easy to get last element statically with the library
-  uint64_t producers[280];  //XED_REG_LAST;
+  // Array containing the sequence number of the producers for each of the registers.
+  std::vector<uint64_t> producers;
 public:
   RegisterDependencies();
 

--- a/common/scripting/py_control.cc
+++ b/common/scripting/py_control.cc
@@ -52,6 +52,7 @@ setProgress(PyObject *self, PyObject *args)
    Py_RETURN_NONE;
 }
 
+#include "trace_manager.h"
 static PyObject *
 simulatorAbort(PyObject *self, PyObject *args)
 {
@@ -60,6 +61,8 @@ simulatorAbort(PyObject *self, PyObject *args)
 
    // If we're still in ROI, make sure we end it properly
    Sim()->getMagicServer()->setPerformance(false);
+   // Ends front-end, such that it does not hang waiting for response.
+   Sim()->getTraceManager()->endFrontEnd();
 
    LOG_PRINT("Application exit.");
    Simulator::release();

--- a/common/scripting/py_stats.cc
+++ b/common/scripting/py_stats.cc
@@ -48,54 +48,12 @@ statsGetterGet(PyObject *self, PyObject *args, PyObject *kw)
 }
 
 static PyTypeObject statsGetterType = {
-   PyObject_HEAD_INIT(NULL)
-   0,                         /*ob_size*/
-   "statsGetter",             /*tp_name*/
-   sizeof(statsGetterObject), /*tp_basicsize*/
-   0,                         /*tp_itemsize*/
-   0,                         /*tp_dealloc*/
-   0,                         /*tp_print*/
-   0,                         /*tp_getattr*/
-   0,                         /*tp_setattr*/
-   0,                         /*tp_compare*/
-   0,                         /*tp_repr*/
-   0,                         /*tp_as_number*/
-   0,                         /*tp_as_sequence*/
-   0,                         /*tp_as_mapping*/
-   0,                         /*tp_hash */
-   statsGetterGet,            /*tp_call*/
-   0,                         /*tp_str*/
-   0,                         /*tp_getattro*/
-   0,                         /*tp_setattro*/
-   0,                         /*tp_as_buffer*/
-   Py_TPFLAGS_DEFAULT,        /*tp_flags*/
-   "Stats getter objects",    /*tp_doc*/
-   0,                         /*tp_traverse*/
-   0,                         /*tp_clear*/
-   0,                         /*tp_richcompare*/
-   0,                         /*tp_weaklistoffset*/
-   0,                         /*tp_iter*/
-   0,                         /*tp_iternext*/
-   0,                         /*tp_methods*/
-   0,                         /*tp_members*/
-   0,                         /*tp_getset*/
-   0,                         /*tp_base*/
-   0,                         /*tp_dict*/
-   0,                         /*tp_descr_get*/
-   0,                         /*tp_descr_set*/
-   0,                         /*tp_dictoffset*/
-   0,                         /*tp_init*/
-   0,                         /*tp_alloc*/
-   0,                         /*tp_new*/
-   0,                         /*tp_free*/
-   0,                         /*tp_is_gc*/
-   0,                         /*tp_bases*/
-   0,                         /*tp_mro*/
-   0,                         /*tp_cache*/
-   0,                         /*tp_subclasses*/
-   0,                         /*tp_weaklist*/
-   0,                         /*tp_del*/
-   0,                         /*tp_version_tag*/
+   .ob_base = PyVarObject_HEAD_INIT(NULL, 0)
+   .tp_name = "statsGetter",
+   .tp_basicsize = sizeof(statsGetterObject),
+   .tp_call = statsGetterGet,
+   .tp_flags = Py_TPFLAGS_DEFAULT,
+   .tp_doc = PyDoc_STR("Stats getter objects"),
 };
 
 static PyObject *

--- a/common/scripting/py_stats.cc
+++ b/common/scripting/py_stats.cc
@@ -48,12 +48,54 @@ statsGetterGet(PyObject *self, PyObject *args, PyObject *kw)
 }
 
 static PyTypeObject statsGetterType = {
-   .ob_base = PyVarObject_HEAD_INIT(NULL, 0)
-   .tp_name = "statsGetter",
-   .tp_basicsize = sizeof(statsGetterObject),
-   .tp_call = statsGetterGet,
-   .tp_flags = Py_TPFLAGS_DEFAULT,
-   .tp_doc = PyDoc_STR("Stats getter objects"),
+   PyObject_HEAD_INIT(NULL)
+   0,                         /*ob_size*/
+   "statsGetter",             /*tp_name*/
+   sizeof(statsGetterObject), /*tp_basicsize*/
+   0,                         /*tp_itemsize*/
+   0,                         /*tp_dealloc*/
+   0,                         /*tp_print*/
+   0,                         /*tp_getattr*/
+   0,                         /*tp_setattr*/
+   0,                         /*tp_compare*/
+   0,                         /*tp_repr*/
+   0,                         /*tp_as_number*/
+   0,                         /*tp_as_sequence*/
+   0,                         /*tp_as_mapping*/
+   0,                         /*tp_hash */
+   statsGetterGet,            /*tp_call*/
+   0,                         /*tp_str*/
+   0,                         /*tp_getattro*/
+   0,                         /*tp_setattro*/
+   0,                         /*tp_as_buffer*/
+   Py_TPFLAGS_DEFAULT,        /*tp_flags*/
+   "Stats getter objects",    /*tp_doc*/
+   0,                         /*tp_traverse*/
+   0,                         /*tp_clear*/
+   0,                         /*tp_richcompare*/
+   0,                         /*tp_weaklistoffset*/
+   0,                         /*tp_iter*/
+   0,                         /*tp_iternext*/
+   0,                         /*tp_methods*/
+   0,                         /*tp_members*/
+   0,                         /*tp_getset*/
+   0,                         /*tp_base*/
+   0,                         /*tp_dict*/
+   0,                         /*tp_descr_get*/
+   0,                         /*tp_descr_set*/
+   0,                         /*tp_dictoffset*/
+   0,                         /*tp_init*/
+   0,                         /*tp_alloc*/
+   0,                         /*tp_new*/
+   0,                         /*tp_free*/
+   0,                         /*tp_is_gc*/
+   0,                         /*tp_bases*/
+   0,                         /*tp_mro*/
+   0,                         /*tp_cache*/
+   0,                         /*tp_subclasses*/
+   0,                         /*tp_weaklist*/
+   0,                         /*tp_del*/
+   0,                         /*tp_version_tag*/
 };
 
 static PyObject *

--- a/common/system/barrier_sync_server.cc
+++ b/common/system/barrier_sync_server.cc
@@ -323,7 +323,7 @@ BarrierSyncServer::barrierRelease(thread_id_t caller_id, bool continue_until_rel
    // To avoid overwhelming the OS scheduler, we only release N threads at a time (N ~= host cores).
    // Once a thread is done (stops executing because it completed the next barrier quantum, or due to thread stall),
    // one more thread is released so we always have at most N running threads.
-   std::random_shuffle(m_to_release.begin(), m_to_release.end());
+   std::shuffle(m_to_release.begin(), m_to_release.end(), generator);
    doRelease(m_fastforward ? -1 : Sim()->getConfig()->getNumHostCores());
 
    return must_wait;

--- a/common/system/barrier_sync_server.h
+++ b/common/system/barrier_sync_server.h
@@ -6,6 +6,7 @@
 #include "hooks_manager.h"
 
 #include <vector>
+#include <random>
 
 class CoreManager;
 
@@ -44,6 +45,7 @@ class BarrierSyncServer : public ClockSkewMinimizationServer
       void threadExit(HooksManager::ThreadTime *argument);
       void threadStall(HooksManager::ThreadStall *argument);
       void threadMigrate(HooksManager::ThreadMigrate *argument);
+      std::default_random_engine generator;
 
    public:
       BarrierSyncServer();

--- a/common/trace_frontend/trace_manager.cc
+++ b/common/trace_frontend/trace_manager.cc
@@ -221,6 +221,14 @@ void TraceManager::endApplication(TraceThread *thread, SubsecondTime time)
    }
 }
 
+void TraceManager::endFrontEnd()
+{
+	for(std::vector<TraceThread *>::iterator it = m_threads.begin(); it != m_threads.end(); ++it){
+		(*it)->frontEndStop();
+	}
+}
+
+
 void TraceManager::cleanup()
 {
    for(std::vector<TraceThread *>::iterator it = m_threads.begin(); it != m_threads.end(); ++it)

--- a/common/trace_frontend/trace_manager.cc
+++ b/common/trace_frontend/trace_manager.cc
@@ -224,7 +224,8 @@ void TraceManager::endApplication(TraceThread *thread, SubsecondTime time)
 void TraceManager::endFrontEnd()
 {
 	for(std::vector<TraceThread *>::iterator it = m_threads.begin(); it != m_threads.end(); ++it){
-		(*it)->frontEndStop();
+		if(!(*it)->m_stopped)
+			(*it)->frontEndStop();
 	}
 }
 

--- a/common/trace_frontend/trace_manager.h
+++ b/common/trace_frontend/trace_manager.h
@@ -75,6 +75,7 @@ class TraceManager
       void signalStarted();
       void signalDone(TraceThread *thread, SubsecondTime time, bool aborted);
       void endApplication(TraceThread *thread, SubsecondTime time);
+      void endFrontEnd(); //Ask all trace_threads to send signal to front-end to shutdown
       void accessMemory(int core_id, Core::lock_signal_t lock_signal, Core::mem_op_t mem_op_type, IntPtr d_addr, char* data_buffer, UInt32 data_size);
 
       UInt64 getProgressExpect();

--- a/common/trace_frontend/trace_thread.cc
+++ b/common/trace_frontend/trace_thread.cc
@@ -875,6 +875,10 @@ UInt64 TraceThread::getProgressValue()
    return m_trace.getPosition();
 }
 
+void TraceThread::frontEndStop(){
+	m_trace.frontEndStop();
+}
+
 void TraceThread::handleAccessMemory(Core::lock_signal_t lock_signal, Core::mem_op_t mem_op_type, IntPtr d_addr, char* data_buffer, UInt32 data_size)
 {
    Sift::MemoryLockType sift_lock_signal;

--- a/common/trace_frontend/trace_thread.h
+++ b/common/trace_frontend/trace_thread.h
@@ -130,6 +130,7 @@ class TraceThread : public Runnable
 
       void spawn();
       void stop() { m_stop = true; }
+      void frontEndStop(); //Ask all trace_threads to send signal to front-end to shutdown
       UInt64 getProgressExpect();
       UInt64 getProgressValue();
       Thread* getThread() const { return m_thread; }

--- a/decoder_lib/decoder.h
+++ b/decoder_lib/decoder.h
@@ -3,6 +3,7 @@
 
 #include <string>
 #include <cassert>
+#include <cstdint>
 
 namespace dl
 {

--- a/docker/Dockerfile-ubuntu-20.04
+++ b/docker/Dockerfile-ubuntu-20.04
@@ -54,6 +54,6 @@ RUN apt-get update && apt-get install -y \
     gdb \
     gfortran \
     git \
-    g++-9 \
+    g++ \
     vim \
  && rm -rf /var/lib/apt/lists/*

--- a/docker/Dockerfile-ubuntu-22.04
+++ b/docker/Dockerfile-ubuntu-22.04
@@ -55,6 +55,6 @@ RUN apt-get update && apt-get install -y \
     gdb \
     gfortran \
     git \
-    g++-9 \
+    g++ \
     vim \
  && rm -rf /var/lib/apt/lists/*

--- a/record-trace
+++ b/record-trace
@@ -155,7 +155,7 @@ execfile(configfile, {}, config)
 arch = config.get('target', 'intel64')
 
 if use_pinplay == False and  os.path.isfile('%s/sift/recorder/obj-%s/sift_recorder' %(HOME, arch)) and \
-    not os.path.isfile('%s/sift/recorder/obj-%s/sde_sift_recorder' %(HOME, arch)):
+    not os.path.isfile('%s/sift/recorder/obj-%s/sde_sift_recorder.so' %(HOME, arch)):
   use_pinplay = True
 
 # convert paths in config to absolute paths

--- a/record-trace
+++ b/record-trace
@@ -261,8 +261,8 @@ if frontend:
 else:
   print '[RECORD-TRACE] Using the Pin frontend (sift/recorder)'
   if not use_pinplay:
-    sde_arch = '-snb'
-    cmd = '%(sde_home)s/sde64 %(sde_arch)s -t64 %(HOME)s/sift/recorder/obj-%(arch)s/sde_sift_recorder -sniper:verbose %(value_verbose)d -sniper:debug %(gdb_screen)d -sniper:roi %(value_roi)d -sniper:roi-mpi %(value_roi_mpi)d -sniper:f %(fastforward)d -sniper:d %(detailed)d -sniper:b %(blocksize)d -sniper:o %(outputfile)s -sniper:e %(syscallemulation)d  -sniper:s %(siftcountoffset)d -sniper:r %(useresponsefiles)d  -sniper:pa %(value_pa)d -sniper:rtntrace  %(value_routine_tracing)d -sniper:stop %(stop_address)d %(pinballoptions)s %(extra_tool_args)s %(extrae)s -- ' % locals() + ' '.join(cmdline)
+    sde_arch = '-use_host_cpuid'
+    cmd = '%(sde_home)s/sde64 %(sde_arch)s -t64 %(HOME)s/sift/recorder/obj-%(arch)s/sde_sift_recorder.so -sniper:verbose %(value_verbose)d -sniper:debug %(gdb_screen)d -sniper:roi %(value_roi)d -sniper:roi-mpi %(value_roi_mpi)d -sniper:f %(fastforward)d -sniper:d %(detailed)d -sniper:b %(blocksize)d -sniper:o %(outputfile)s -sniper:e %(syscallemulation)d  -sniper:s %(siftcountoffset)d -sniper:r %(useresponsefiles)d  -sniper:pa %(value_pa)d -sniper:rtntrace  %(value_routine_tracing)d -sniper:stop %(stop_address)d %(pinballoptions)s %(extra_tool_args)s %(extrae)s -- ' % locals() + ' '.join(cmdline)
   else:
     cmd = '%(pin_home)s/pin %(pinoptions)s -t %(HOME)s/sift/recorder/obj-%(arch)s/sift_recorder -sniper:verbose %(value_verbose)d -sniper:debug %(gdb_screen)d -sniper:roi %(value_roi)d -sniper:roi-mpi %(value_roi_mpi)d -sniper:f %(fastforward)d -sniper:d %(detailed)d -sniper:b %(blocksize)d -sniper:o %(outputfile)s -sniper:e %(syscallemulation)d -sniper:s %(siftcountoffset)d -sniper:r %(useresponsefiles)d -sniper:pa %(value_pa)d -sniper:rtntrace %(value_routine_tracing)d -sniper:stop %(stop_address)d %(pinballoptions)s %(extra_tool_args)s %(extrae)s -- ' % locals() + ' '.join(cmdline)
 

--- a/run-sniper
+++ b/run-sniper
@@ -4,7 +4,6 @@ import sys, os, time, getopt, tempfile, subprocess, threading, platform, pprint,
 sys.path.append(os.path.join(os.path.dirname(__file__), 'tools'))
 import sniper_lib, sniper_config, gen_simout, debugpin, env_setup, run_sniper
 
-
 HOME = env_setup.sim_root()
 
 

--- a/sift/recorder/makefile.sde.rules
+++ b/sift/recorder/makefile.sde.rules
@@ -77,7 +77,7 @@ LINK_LIBS = sift/$(OBJDIR)libsift.a $(PINPLAY_LIBS)
 SOURCES=$(wildcard *.cc) $(wildcard ../bbv_count.cc)
 OBJECTS=$(patsubst %.cc,$(OBJDIR)%$(OBJ_SUFFIX),$(SOURCES))
 
-all: sift/$(OBJDIR)libsift.a $(OBJDIR)sde_sift_recorder
+all: sift/$(OBJDIR)libsift.a $(OBJDIR)sde_sift_recorder$(PINTOOL_SUFFIX)
 
 $(OBJDIR)%$(OBJ_SUFFIX) : %.cc $(wildcard *.h)
 	$(_MSG) '[CXX   ]' $(subst $(shell readlink -f $(ROOT_DIR)/../..)/,,$(shell readlink -f $@))
@@ -91,12 +91,15 @@ sift/sift_reader.h: sift
 sift/$(OBJDIR)libsift.a: sift/sift_reader.h $(wildcard sift/*.h) $(wildcard sift/*.cc)
 	@$(MAKE) -C sift
 
-export PYTHONPATH := $(SDE_BUILD_KIT)/pinplay-tools/pinplay-scripts:$(SIM_ROOT)/mbuild
-$(OBJDIR)sde_sift_recorder: $(wildcard *.cc *.h sift/*.cc sift/*.h)
+CC ?= gcc
+CXX ?= g++
+# export PYTHONPATH := $(SDE_BUILD_KIT)/pinplay-tools/pinplay-scripts:$(SIM_ROOT)/mbuild
+export PYTHONPATH := $(SDE_BUILD_KIT)/pinplay-tools/pinplay-scripts:$(SDE_BUILD_KIT)/pinkit/sde-example/mbuild
+$(OBJDIR)sde_sift_recorder$(PINTOOL_SUFFIX): $(wildcard *.cc *.h sift/*.cc sift/*.h)
 ifeq ($(ARCH_QUERY),x86_64)
-	@./mfile.py --host-cpu intel64
+	@CC=$(CC) CXX=$(CXX) ./mfile.py --host-cpu intel64
 else
-	@./mfile.py --host-cpu ia32
+	@CC=$(CC) CXX=$(CXX) ./mfile.py --host-cpu ia32
 endif
 
 CLEAN=$(findstring clean,$(MAKECMDGOALS))

--- a/sift/recorder/threads.h
+++ b/sift/recorder/threads.h
@@ -33,6 +33,7 @@ typedef struct {
    BOOL last_syscall_emulated;
    BOOL running;
    BOOL should_send_threadinfo;
+   Sift::EmuReply cpuid_vals;
 } __attribute__((packed,aligned(LINE_SIZE_BYTES))) thread_data_t;
 
 extern thread_data_t *thread_data;

--- a/sift/sift_format.h
+++ b/sift/sift_format.h
@@ -115,6 +115,7 @@ namespace Sift
       RecOtherInstructionCount,
       RecOtherCacheOnly,
       RecOtherISAChange,
+      RecOtherShutdown,
       RecOtherEnd = 0xff,
    } RecOtherType;
 

--- a/sift/sift_reader.cc
+++ b/sift/sift_reader.cc
@@ -310,7 +310,7 @@ bool Sift::Reader::Read(Instruction &inst)
                hexdump((char*)bytes, size);
                #endif
                #if VERBOSE > 1
-               for (int i = 0 ; i < (size/8) ; i++)
+               for (unsigned i = 0 ; i < (size/8) ; i++)
                {
                   std::cerr << __FUNCTION__ << ": syscall args[" << i << "] = " << ((uint64_t*)bytes)[i] << std::endl;
                }
@@ -801,3 +801,10 @@ uint64_t Sift::Reader::va2pa(uint64_t va)
       return va;
    }
 }
+
+void Sift::Reader::frontEndStop()
+{
+    if(response)
+	sendSimpleResponse(RecOtherType::RecOtherShutdown, NULL, 0);
+}
+

--- a/sift/sift_reader.h
+++ b/sift/sift_reader.h
@@ -124,6 +124,8 @@ namespace Sift
          uint64_t getLength();
          bool getTraceHasPhysicalAddresses() const { return m_trace_has_pa; }
          uint64_t va2pa(uint64_t va);
+
+	 void frontEndStop();
    };
 };
 

--- a/sift/sift_writer.cc
+++ b/sift/sift_writer.cc
@@ -115,7 +115,8 @@ void Sift::Writer::initResponse()
    if (!response)
    {
      sift_assert(strcmp(m_response_filename, "") != 0);
-     response = new vifstream(m_response_filename, std::ios::in);
+     //response = new vifstream(m_response_filename, std::ios::in);
+     response = new cvifstream(m_response_filename, std::ios_base::in);
      sift_assert(!response->fail());
    }
 }
@@ -169,12 +170,12 @@ Sift::Writer::~Writer()
    #if VERBOSE > 3
    printf("instrs %lu hsize", ninstrs);
    for(int i = 1; i < 16; ++i)
-      printf(" %u", hsize[i]);
+      printf(" %lu", hsize[i]);
    printf(" haddr");
-   for(int i = 1; i <= MAX_DYNAMIC_ADDRESSES; ++i)
-      printf(" %u", haddr[i]);
-   printf(" branch %u predicate %u\n", nbranch, npredicate);
-   printf("instrsmall %u ext %u\n", ninstrsmall, ninstrext);
+   for(unsigned i = 1; i <= MAX_DYNAMIC_ADDRESSES; ++i)
+      printf(" %lu", haddr[i]);
+   printf(" branch %lu predicate %lu\n", nbranch, npredicate);
+   printf("instrsmall %lu ext %lu\n", ninstrsmall, ninstrext);
    #endif
 }
 
@@ -353,6 +354,8 @@ Sift::Mode Sift::Writer::InstructionCount(uint32_t icount)
    }
    if (respRec.Other.type != RecOtherSyncResponse)
    {
+	if (respRec.Other.type == RecOtherShutdown)
+		frontEndStop();
       return Sift::ModeUnknown;
    }
    Mode mode;
@@ -476,6 +479,9 @@ int32_t Sift::Writer::NewThread()
             #endif
             return retcode;
             break;
+	 case RecOtherShutdown:
+	    frontEndStop();
+	    break;
          default:
             return -1;
             break;
@@ -567,6 +573,9 @@ uint64_t Sift::Writer::Syscall(uint16_t syscall_number, const char *data, uint32
          case RecOtherMemoryRequest:
             handleMemoryRequest(respRec);
             break;
+	 case RecOtherShutdown:
+	    frontEndStop();
+	    break;
       }
    }
 
@@ -624,6 +633,9 @@ int32_t Sift::Writer::Join(int32_t thread)
             response->read(reinterpret_cast<char*>(&retcode), sizeof(retcode));
             return retcode;
             break;
+	 case RecOtherShutdown:
+	    frontEndStop();
+	    break;
          default:
             return -1;
             break;
@@ -678,6 +690,9 @@ Sift::Mode Sift::Writer::Sync()
          case RecOtherMemoryRequest:
             handleMemoryRequest(respRec);
             break;
+	 case RecOtherShutdown:
+	    frontEndStop();
+	    break;
          default:
             return Sift::ModeUnknown;
             break;
@@ -717,6 +732,8 @@ int32_t Sift::Writer::Fork()
    }
    if (respRec.Other.type != RecOtherForkResponse)
    {
+      if (respRec.Other.type == RecOtherShutdown)
+	frontEndStop();
       return -1;
    }
    if (respRec.Other.size != sizeof(int32_t))
@@ -773,6 +790,9 @@ uint64_t Sift::Writer::Magic(uint64_t a, uint64_t b, uint64_t c)
          case RecOtherMemoryRequest:
             handleMemoryRequest(respRec);
             break;
+	 case RecOtherShutdown:
+	    frontEndStop();
+	    break;
          default:
             sift_assert(false);
             break;
@@ -825,6 +845,9 @@ bool Sift::Writer::Emulate(Sift::EmuType type, Sift::EmuRequest &req, Sift::EmuR
          case RecOtherMemoryRequest:
             handleMemoryRequest(respRec);
             break;
+	 case RecOtherShutdown:
+	    frontEndStop();
+	    break;
          default:
             return false;
             break;
@@ -1091,4 +1114,10 @@ void Sift::Writer::send_va2pa(uint64_t va)
          }
       }
    }
+}
+
+void Sift::Writer::frontEndStop(){
+// front end has been shut-down, shut-down ourselves as well...
+	printf("[FRONT-END] Front-end being forcefully stopped\n");
+	exit(0);
 }

--- a/sift/sift_writer.h
+++ b/sift/sift_writer.h
@@ -43,6 +43,8 @@ namespace Sift
          void send_va2pa(uint64_t va);
          uint64_t va2pa_lookup(uint64_t va);
 
+	 void frontEndStop();
+
       public:
          Writer(const char *filename, GetCodeFunc getCodeFunc, bool useCompression = false, const char *response_filename = "", uint32_t id = 0, bool arch32 = false, bool requires_icache_per_insn = false, bool send_va2pa_mapping = false, GetCodeFunc2 getCodeFunc2 = NULL, void *GetCodeFunc2Data = NULL);
          ~Writer();

--- a/sift/zfstream.h
+++ b/sift/zfstream.h
@@ -92,6 +92,22 @@ class vifstream : public vistream
       virtual bool fail() const { return stream->fail(); }
 };
 
+class cvifstream : public vistream
+{
+   private:
+	   std::FILE *stream;
+	   char peek_buffer;
+	   bool buffer_in_use;
+   public:
+	   cvifstream(const char * filename, std::ios_base::openmode mode = std::ios_base::in);
+	   cvifstream(std::FILE *stream)
+		   : stream(stream) {}
+	   virtual ~cvifstream();
+	   virtual void read(char* s, std::streamsize n);
+	   virtual int peek();
+	   virtual bool fail() const; 
+};
+
 class izstream : public vistream
 {
    private:


### PR DESCRIPTION
Found an alternative to the LLVM bug that prevents the ifstream to read properly. The c-api's were used instead to circumvent the problem. More information can be found at:
- https://github.com/llvm/llvm-project/issues/23452
- https://groups.io/g/pinheads/topic/93223390?p=Created,,,20,1,0,0

Furthermore SDE/PIN introduced a bug where overwriting the RAX, RBX, RCX, and RDX, might not last after emulating the CPUID instruction. This has been solved, by re-assigning those values after the (deleted) CPUID instruction. Note that changing the CPUID of SDE will probably have no effect, as the back-end will execute the CPUID instruction.

Lastly a little update to the python_scripts, to gracefully shut down the front-end, after a stop-by-icount.

Moreover, this compiles on c++20 as well.

Note to the request of @alenks, this pull request was part of https://github.com/snipersim/snipersim/pull/10 , but has been split into different feature branches