### PR TITLE
Dockerfiles upgrade

### DIFF
--- a/docker/Dockerfile-ubuntu-16.04
+++ b/docker/Dockerfile-ubuntu-16.04
@@ -1,3 +1,4 @@
+# Not going to fix, make sure python is at least python3.8
 FROM ubuntu:16.04
 # Add i386 support for support for Pin
 RUN dpkg --add-architecture i386

--- a/docker/Dockerfile-ubuntu-18.04
+++ b/docker/Dockerfile-ubuntu-18.04
@@ -1,3 +1,4 @@
+# Not going to fix, make sure python is at least python3.8
 FROM ubuntu:18.04
 # Add i386 support for support for Pin
 RUN dpkg --add-architecture i386

--- a/docker/Dockerfile-ubuntu-20.04
+++ b/docker/Dockerfile-ubuntu-20.04
@@ -6,7 +6,9 @@ ENV TZ=${TZ_ARG}
 # Add i386 support for support for Pin
 RUN dpkg --add-architecture i386
 RUN apt-get update && apt-get install -y \
-    python \
+    python3 \
+    python3-dev \
+    python3-venv \
     screen \
     tmux \
     binutils \
@@ -25,6 +27,7 @@ RUN apt-get update && apt-get install -y \
     libsqlite3-dev \
     zlib1g-dev \
     libbz2-dev \
+    libdb++-dev \
  && rm -rf /var/lib/apt/lists/*
 # For building RISC-V Tools
 RUN apt-get update && apt-get install -y \

--- a/docker/Dockerfile-ubuntu-22.04
+++ b/docker/Dockerfile-ubuntu-22.04
@@ -6,8 +6,9 @@ ENV TZ=${TZ_ARG}
 # Add i386 support for support for Pin
 RUN dpkg --add-architecture i386
 RUN apt-get update && apt-get install -y \
-    python2 \
     python3 \
+    python3-dev \
+    python3-venv \
     screen \
     tmux \
     binutils \
@@ -26,6 +27,7 @@ RUN apt-get update && apt-get install -y \
     libsqlite3-dev \
     zlib1g-dev \
     libbz2-dev \
+    libdb++-dev \
  && rm -rf /var/lib/apt/lists/*
 # For building RISC-V Tools
 RUN apt-get update && apt-get install -y \

--- a/docker/Dockerfile-ubuntu-24.04
+++ b/docker/Dockerfile-ubuntu-24.04
@@ -1,0 +1,57 @@
+FROM ubuntu:24.04
+# Necessary for tzdata
+ENV DEBIAN_FRONTEND=noninteractive
+ARG TZ_ARG=UTC
+ENV TZ=${TZ_ARG}
+RUN apt-get update && apt-get install -y \
+    python3 \
+    python3-dev \
+    python3-venv \
+    screen \
+    tmux \
+    binutils \
+ && rm -rf /var/lib/apt/lists/*
+# For building Sniper
+RUN apt-get update && apt-get install -y \
+    automake \
+    build-essential \
+    cmake \
+    curl \
+    wget \
+    libboost-dev \
+    libsqlite3-dev \
+    zlib1g-dev \
+    libbz2-dev \
+    libdb++-dev \
+ && rm -rf /var/lib/apt/lists/*
+# For building RISC-V Tools
+RUN apt-get update && apt-get install -y \
+    autoconf \
+    automake \
+    autotools-dev \
+    bc \
+    bison \
+    curl \
+    device-tree-compiler \
+    flex \
+    gawk \
+    gperf \
+    libexpat-dev \
+    libgmp-dev \
+    libmpc-dev \
+    libmpfr-dev \
+    libtool \
+    libusb-1.0-0-dev \
+    patchutils \
+    pkg-config \
+    texinfo \
+    zlib1g-dev \
+ && rm -rf /var/lib/apt/lists/*
+# Helper utilities
+RUN apt-get update && apt-get install -y \
+    gdb \
+    gfortran \
+    git \
+    g++ \
+    vim \
+ && rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
This dockerfile upgrade is to accommodate for the changes done with pull request https://github.com/snipersim/snipersim/pull/11, https://github.com/snipersim/snipersim/pull/12 and https://github.com/snipersim/snipersim/pull/14 (`libdb++-dev` is required to build `McPat`-cache version.

Ubuntu 24.04 is now also added.

However with Ubuntu 16.04 LTS reaching End of Standard support in April 2021, and Ubuntu 18.04 LTS reaching End of standard support in April 2024. I don't think it is worth upgrading those files. (Although I did not delete the files, would the Sniper maintainers wish to upgrade the dockerfiles anyway.)

Please merge this pull request only after having merged the three pull request listed above.

Note: to the request of @alenks, this pull request was part of https://github.com/snipersim/snipersim/pull/10 , but has been split into different feature branches.