### PR TITLE
Fixed SDE-9.44.0 and lock bug on writethrough caches

### DIFF
--- a/common/core/memory_subsystem/parametric_dram_directory_msi/cache_cntlr.cc
+++ b/common/core/memory_subsystem/parametric_dram_directory_msi/cache_cntlr.cc
@@ -1735,9 +1735,13 @@ assert(data_length==getCacheBlockSize());
    }
 
    if (m_cache_writethrough) {
-      acquireStackLock(true);
+      #ifdef PRIVATE_L2_OPTIMIZATION
+      acquireStackLock(address, true);
       m_next_cache_cntlr->writeCacheBlock(address, offset, data_buf, data_length, thread_num);
-      releaseStackLock(true);
+      releaseStackLock(address, true);
+      #else
+      m_next_cache_cntlr->writeCacheBlock(address, offset, data_buf, data_length, thread_num);
+      #endif
    }
 }
 

--- a/run-sniper
+++ b/run-sniper
@@ -106,7 +106,7 @@ trace_extra_args = []
 verbose = False
 use_pa = True
 use_pinplay = False
-sde_arch = ''
+sde_arch = 'future'
 
 if not sys.argv[1:]:
   usage()
@@ -648,8 +648,7 @@ if tracegen:
     trace_extra_args += [ '--pinplay-addr-trans' ]
   if frontend:
     trace_extra_args += [ '--frontend=%(frontend)s' % locals()]
-  if sde_arch:
-    trace_extra_args += [ '--sde-arch=%(sde_arch)s' % locals() ]
+  trace_extra_args += [ '--sde-arch=%(sde_arch)s' % locals() ]
   for app_id, (pre_cmd, app_cmd) in enumerate(applications):
     tracecmd = pre_cmd + [ os.path.join(HOME, 'record-trace'), '-o', traceprefix ] + (['-v'] if verbose else []) + trace_extra_args + app_cmd
     tracecmds.append(tracecmd)


### PR DESCRIPTION
When running Sniper 8.1 using sde-9.44.0 on some recent processors (Intel Core i7-11700), the following error occurred:

SDE ERROR: valid
Unexpected invalid CPUID leaf
at (no-file):139 Function (no-func)
A: /tmp_proj/sde_jen/workspace/pypl-sde-nightly-master/GitSDE-master-9.44.0-dev-24-gac5cad0f4/pin/Source/pin/vm_u/vm_signal_impl_unix.cpp: NotifyExit: 1248: assertion failed: _initialized
...
Detach Service Count: 1
Pin: pin-3.31-98861-71afcc22f
Copyright 2002-2024 Intel Corporation.

Aborted (core dumped)

This issue occurs due to unsupported instructions. To ensure that the simulator has access to all available instructions, it is recommended that you run SDE with the—future option. This flag extends the emulator's coverage to support all instructions, regardless of the processor generation.

The modification to the run-sniper.py script sets the -future flag as the default when running SDE, allowing emulation of any instructions introduced in newer processors. This choice provides the broadest range of instruction compatibility, ensuring more robust execution and compatibility with recent architectures.