### PR TITLE
McPat 1.3

### DIFF
--- a/docker/Dockerfile-ubuntu-20.04
+++ b/docker/Dockerfile-ubuntu-20.04
@@ -27,7 +27,7 @@ RUN apt-get update && apt-get install -y \
     libsqlite3-dev \
     zlib1g-dev \
     libbz2-dev \
-    libdb++-dev \
+    libldmb-dev \
  && rm -rf /var/lib/apt/lists/*
 # For building RISC-V Tools
 RUN apt-get update && apt-get install -y \

--- a/docker/Dockerfile-ubuntu-20.04
+++ b/docker/Dockerfile-ubuntu-20.04
@@ -27,7 +27,7 @@ RUN apt-get update && apt-get install -y \
     libsqlite3-dev \
     zlib1g-dev \
     libbz2-dev \
-    libldmb-dev \
+    liblmdb-dev \
  && rm -rf /var/lib/apt/lists/*
 # For building RISC-V Tools
 RUN apt-get update && apt-get install -y \

--- a/docker/Dockerfile-ubuntu-22.04
+++ b/docker/Dockerfile-ubuntu-22.04
@@ -27,7 +27,7 @@ RUN apt-get update && apt-get install -y \
     libsqlite3-dev \
     zlib1g-dev \
     libbz2-dev \
-    libdb++-dev \
+    libldmb-dev \
  && rm -rf /var/lib/apt/lists/*
 # For building RISC-V Tools
 RUN apt-get update && apt-get install -y \

--- a/docker/Dockerfile-ubuntu-22.04
+++ b/docker/Dockerfile-ubuntu-22.04
@@ -27,7 +27,7 @@ RUN apt-get update && apt-get install -y \
     libsqlite3-dev \
     zlib1g-dev \
     libbz2-dev \
-    libldmb-dev \
+    liblmdb-dev \
  && rm -rf /var/lib/apt/lists/*
 # For building RISC-V Tools
 RUN apt-get update && apt-get install -y \

--- a/docker/Dockerfile-ubuntu-24.04
+++ b/docker/Dockerfile-ubuntu-24.04
@@ -22,7 +22,7 @@ RUN apt-get update && apt-get install -y \
     libsqlite3-dev \
     zlib1g-dev \
     libbz2-dev \
-    libdb++-dev \
+    libldmb-dev \
  && rm -rf /var/lib/apt/lists/*
 # For building RISC-V Tools
 RUN apt-get update && apt-get install -y \

--- a/docker/Dockerfile-ubuntu-24.04
+++ b/docker/Dockerfile-ubuntu-24.04
@@ -22,7 +22,7 @@ RUN apt-get update && apt-get install -y \
     libsqlite3-dev \
     zlib1g-dev \
     libbz2-dev \
-    libldmb-dev \
+    liblmdb-dev \
  && rm -rf /var/lib/apt/lists/*
 # For building RISC-V Tools
 RUN apt-get update && apt-get install -y \

--- a/tools/mcpat.py
+++ b/tools/mcpat.py
@@ -80,24 +80,20 @@ def mcpat_path():
   return os.path.join(os.path.dirname(__file__), '../mcpat/')
 
 def mcpat_bin():
-  import platform
   mcpatdir = mcpat_path()
-  if platform.architecture()[0] != '64bit':
-    suffix = '.32'
-  elif True: # Disable if you don't want the McPAT/CACTI cache
-    suffix = '.cache'
+  binary = os.path.join(mcpatdir, 'mcpat')
+  if os.path.exists(binary):
+    return binary
   else:
-    suffix = ''
-  bin = os.path.join(mcpatdir, 'mcpat-1.0%s' % suffix)
-  if os.path.exists(bin):
-    # Fancy McPAT versions haven't been downloaded yet, use the plain old one
-    return bin
-  else:
-    os.path.join(mcpatdir, 'mcpat-1.0')
+      return None
 
 def mcpat_run(inputfile, outputfile):
+  binary = mcpat_bin()
+  if not binary:
+      print("McPat Binary was not found")
+      exit(1)
   os.system("LD_LIBRARY_PATH=$LD_LIBRARY_PATH:%s %s -print_level 5 -opt_for_clk 1 -infile %s > %s" % \
-    (mcpat_path(), mcpat_bin(), inputfile, outputfile))
+    (mcpat_path(), binary, inputfile, outputfile))
 
 
 all_items = [


### PR DESCRIPTION
Using the sniper McPat patch-file, I have performed similar changes on the latest McPat 1.3, on this git: https://github.com/JaimeRoelandts/McPat_Sniper (on the `sniper` branch).
As a summary, the major changes are:
- Using vectors instead of fixed arrays to parse the XML. As the original code had buffer overflows, and had a hard limit on resources
- Using the boost library to parse the XML file instead of a built-in XML-parser.
- Usage of memoization to avoid recomputation for the same input. Previously the Sniper Patch file used Berkley Database (BDB). But has been upgraded to use the Lightning Memory-Mapped Database (LMDB) instead, which should be available as liblmdb-dev on most linux systems.
- Various clean-up

Because the current Makefile downloads a McPat binary, instead of builts it. I cannot include the binary or source files in this pull request. But please consider building the source file, make the necessary changes to the Makefile, and necessary uploads to the snipersim servers.

Not included in this pull request is a change to the Makefile, to check whether `liblmdb-dev` is installed, then builds the correct version, and uses that instead. Removing the need to use different suffixes for the `mcpat` binary. (The reason it is not present in this pull-request, is because I will continue to use git-submodules instead of cloning the repository during make. Therefore, the changes in the makefile are not compatible with the way the main project handles dependent projects. The full changes on my version can be seen [here](https://github.com/JaimeRoelandts/snipersim/commit/5a43da3769cbef50adb91f9ff41870ceeb3ba3c3).)