### PR TITLE
Update to raw-strings due to python complain of $ as an invalid escape character

### DIFF
--- a/sift/recorder/mfile.py
+++ b/sift/recorder/mfile.py
@@ -118,8 +118,8 @@ env.add_link_dir(pin_lib_dir)
 env.add_link_dir(pin_crt_dir)
 env.add_link_dir('./sift/obj-intel64')
 if env.on_linux():
-    env['LINKFLAGS'] += ' -Wl,--hash-style=sysv '
-    env['LINKFLAGS'] += ' -Wl,--rpath,\$ORIGIN/../../../../%(arch)s/pin_lib:\$ORIGIN/../../../../%(arch)s/xed_lib:\$ORIGIN/pin_lib:\$ORIGIN/xed_lib'
+    env['LINKFLAGS'] += r' -Wl,--hash-style=sysv '
+    env['LINKFLAGS'] += r' -Wl,--rpath,\$ORIGIN/../../../../%(arch)s/pin_lib:\$ORIGIN/../../../../%(arch)s/xed_lib:\$ORIGIN/pin_lib:\$ORIGIN/xed_lib'
 
 # Tools sources
 tool_sources = {}


### PR DESCRIPTION
Python 3.12 tries to interpret the escaped characters, which should not be. Changing the string to a raw-string avoids this, and suppresses the python warnings at compile-time.