### PR TITLE
NUCA Cache writebacks bug fix

### DIFF
--- a/common/core/memory_subsystem/parametric_dram_directory_msi/nuca_cache.cc
+++ b/common/core/memory_subsystem/parametric_dram_directory_msi/nuca_cache.cc
@@ -112,6 +112,9 @@ NucaCache::write(IntPtr address, Byte* data_buf, bool& eviction, IntPtr& evict_a
          }
       }
 
+      if (count)
+         ((PrL1CacheBlockInfo*)m_cache->peekSingleLine(address))->setCState(CacheState::MODIFIED);
+
       if (count) ++m_write_misses;
    }
    if (count) ++m_writes;

--- a/common/core/memory_subsystem/parametric_dram_directory_msi/nuca_cache.cc
+++ b/common/core/memory_subsystem/parametric_dram_directory_msi/nuca_cache.cc
@@ -112,8 +112,12 @@ NucaCache::write(IntPtr address, Byte* data_buf, bool& eviction, IntPtr& evict_a
          }
       }
 
-      if (count)
+
+      if (count) {
+         // The writebacks coming from upper levels and not found here need to be marked MODIFIED
+         // in order to be written back to the DRAM later on
          ((PrL1CacheBlockInfo*)m_cache->peekSingleLine(address))->setCState(CacheState::MODIFIED);
+      }
 
       if (count) ++m_write_misses;
    }


### PR DESCRIPTION
If we get a miss for a dirty block being written back to the NUCA cache, we need to mark it MODIFIED (dirty) so that it will be written back to the DRAM later. Not doing this will result in DRAM writebacks being skipped.