### PR TITLE
Fix error: template-id not allowed for constructor/destructor in C++20

### DIFF
--- a/frontend/frontend.h
+++ b/frontend/frontend.h
@@ -92,10 +92,10 @@ template <typename T> class ExecFrontend
 {
   public:
   /// Constructor: uses the command line arguments to initialize the running environment
-  ExecFrontend<T>(int argc, const char* argv[]);
+  ExecFrontend(int argc, const char* argv[]);
 
   /// Destructor
-  ~ExecFrontend<T>();
+  ~ExecFrontend();
 
   /// Initializes all data and starts the execution of the frontend
   void start();

--- a/frontend/frontend_callbacks.h
+++ b/frontend/frontend_callbacks.h
@@ -21,10 +21,10 @@ template <typename T> class FrontendCallbacks
 {
   public:
   /// Constructor
-  FrontendCallbacks<T>(FrontendOptions<T>* opts, FrontendControl<T>* cntrl, thread_data_t* td);
+  FrontendCallbacks(FrontendOptions<T>* opts, FrontendControl<T>* cntrl, thread_data_t* td);
 
   /// Destructor
-  ~FrontendCallbacks<T>();
+  ~FrontendCallbacks();
   
   
   /// Method to update the instruction count in the frontend and the backend.

--- a/frontend/frontend_control.h
+++ b/frontend/frontend_control.h
@@ -22,10 +22,10 @@ template <typename T> class FrontendControl
 {
   public:
   /// Constructor
-  FrontendControl<T>(FrontendOptions<T>* opts, thread_data_t* td, rombauts::shared_ptr<FrontendSyscallModel<T>> sysmodel);
+  FrontendControl(FrontendOptions<T>* opts, thread_data_t* td, rombauts::shared_ptr<FrontendSyscallModel<T>> sysmodel);
 
   /// Destructor
-  ~FrontendControl<T>();
+  ~FrontendControl();
   
   /// Closes all the communication pipes between frontend and Sniper backend threads
   static void Fini(int32_t code, void *v);

--- a/frontend/frontend_syscall.h
+++ b/frontend/frontend_syscall.h
@@ -23,10 +23,10 @@ template <typename T> class FrontendSyscallModelBase
 {
   public:
   /// Constructor
-  FrontendSyscallModelBase<T>(FrontendOptions<T>* opts, thread_data_t* td, FELock<T> *ntid_lock, std::deque<uint64_t>* tids);
+  FrontendSyscallModelBase(FrontendOptions<T>* opts, thread_data_t* td, FELock<T> *ntid_lock, std::deque<uint64_t>* tids);
 
   /// Destructor
-  ~FrontendSyscallModelBase<T>();
+  ~FrontendSyscallModelBase();
   
   /// To obtain data accessed by memory instructions in a safe way
   /// This method is passed to Sniper's bridge (trace manager) between frontend and backend.


### PR DESCRIPTION
This pull-request fixes the compilation issues related to the C++20 standard, according to patch [DR 2237](https://gcc.gnu.org/pipermail/gcc-patches/2020-May/546183.html).

Thanks to [kamiel-m](https://github.com/kamiel-m) for submitting the pull-request on my fork.